### PR TITLE
Bugfix in dxl module.

### DIFF
--- a/Drivers/Dxl/dxl.c
+++ b/Drivers/Dxl/dxl.c
@@ -454,7 +454,7 @@ void dxl_loop(void) {
             errors = servo_get_raw_word(dxl_table[id], SERVO_REGISTER_PRESENT_TEMPERATURE, &tmp_val, DXL_TIMEOUT);
             if ((errors != SERVO_ERROR_TIMEOUT) & (errors != SERVO_ERROR_INVALID_RESPONSE)){
                 temperature[id] = tmp_val;
-                last_temp[MAX_VM_NUMBER] = HAL_GetTick();
+                last_temp[id] = HAL_GetTick();
             }
         }
     }


### PR DESCRIPTION
Fix a bug in the dxl module example. 

The last_temp is written beyond the table limit that may leads to random behaviour.