### PR TITLE
Dxl compliant fix

### DIFF
--- a/Drivers/Dxl/dxl.c
+++ b/Drivers/Dxl/dxl.c
@@ -405,7 +405,7 @@ void dxl_request_manager(void)
                 {
                     int pos = (int)((1024 - 1) * ((300 / 2 + dxl[last].val) / 300));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MIN_ANGLE, pos, DXL_TIMEOUT);
-                    HAL_Delay(500);
+                    HAL_Delay(1);
                     pos = (int)((1024 - 1) * ((300 / 2 + dxl[last].val2) / 300));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MAX_ANGLE, pos, DXL_TIMEOUT);
                 }
@@ -413,7 +413,7 @@ void dxl_request_manager(void)
                 {
                     int pos = (int)((4096 - 1) * ((360 / 2 + dxl[last].val) / 360));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MIN_ANGLE, pos, DXL_TIMEOUT);
-                    HAL_Delay(500);
+                    HAL_Delay(1);
                     pos = (int)((4096 - 1) * ((360 / 2 + dxl[last].val2) / 360));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MAX_ANGLE, pos, DXL_TIMEOUT);
                 }

--- a/Drivers/Dxl/dxl.c
+++ b/Drivers/Dxl/dxl.c
@@ -188,7 +188,18 @@ void rx_dxl_cb(module_t *module, msg_t *msg)
         {
             last = 0;
         }
-        dxl[last].val = position[find_id(module)];
+        angular_position_t value;
+        // convert data into deg
+        int i = find_id(module);
+        if (dxl_model[i] == AX12 || dxl_model[i] == AX18 || dxl_model[i] == XL320)
+        {
+            value = ((300.0 * (float)position[i]) / (1024.0 - 1.0)) - (300.0 / 2);
+        }
+        else
+        {
+            value = ((360.0 * (float)position[i]) / (4096.0 - 1.0)) - (360.0 / 2);
+        }
+        dxl[last].val = value;
         dxl[last].module_pointer = module;
         dxl[last].mode = MODE_ANGLE;
         last++;

--- a/Drivers/Dxl/dxl.c
+++ b/Drivers/Dxl/dxl.c
@@ -188,26 +188,29 @@ void rx_dxl_cb(module_t *module, msg_t *msg)
         {
             last = 0;
         }
-        angular_position_t value;
-        // convert data into deg
-        int i = find_id(module);
-        if (dxl_model[i] == AX12 || dxl_model[i] == AX18 || dxl_model[i] == XL320)
+        if ((int)msg->data[0] == 0) // STIFF
         {
-            value = ((300.0 * (float)position[i]) / (1024.0 - 1.0)) - (300.0 / 2);
+            angular_position_t value;
+            // convert data into deg
+            int i = find_id(module);
+            if (dxl_model[i] == AX12 || dxl_model[i] == AX18 || dxl_model[i] == XL320)
+            {
+                value = ((300.0 * (float)position[i]) / (1024.0 - 1.0)) - (300.0 / 2);
+            }
+            else
+            {
+                value = ((360.0 * (float)position[i]) / (4096.0 - 1.0)) - (360.0 / 2);
+            }
+            dxl[last].val = value;
+            dxl[last].module_pointer = module;
+            dxl[last].mode = MODE_ANGLE;
+            last++;
+            if (last == MAX_VM_NUMBER)
+            {
+                last = 0;
+            }
+            request_nb++;
         }
-        else
-        {
-            value = ((360.0 * (float)position[i]) / (4096.0 - 1.0)) - (360.0 / 2);
-        }
-        dxl[last].val = value;
-        dxl[last].module_pointer = module;
-        dxl[last].mode = MODE_ANGLE;
-        last++;
-        if (last == MAX_VM_NUMBER)
-        {
-            last = 0;
-        }
-        request_nb++;
         return;
     }
     if (msg->header.cmd == ASK_PUB_CMD)
@@ -402,7 +405,7 @@ void dxl_request_manager(void)
                 {
                     int pos = (int)((1024 - 1) * ((300 / 2 + dxl[last].val) / 300));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MIN_ANGLE, pos, DXL_TIMEOUT);
-                    HAL_Delay(1);
+                    HAL_Delay(500);
                     pos = (int)((1024 - 1) * ((300 / 2 + dxl[last].val2) / 300));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MAX_ANGLE, pos, DXL_TIMEOUT);
                 }
@@ -410,7 +413,7 @@ void dxl_request_manager(void)
                 {
                     int pos = (int)((4096 - 1) * ((360 / 2 + dxl[last].val) / 360));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MIN_ANGLE, pos, DXL_TIMEOUT);
-                    HAL_Delay(1);
+                    HAL_Delay(500);
                     pos = (int)((4096 - 1) * ((360 / 2 + dxl[last].val2) / 360));
                     servo_set_raw_word(dxl_table[i], SERVO_REGISTER_MAX_ANGLE, pos, DXL_TIMEOUT);
                 }

--- a/Drivers/Dxl/dxl.c
+++ b/Drivers/Dxl/dxl.c
@@ -195,13 +195,13 @@ void rx_dxl_cb(module_t *module, msg_t *msg)
             int i = find_id(module);
             if (dxl_model[i] == AX12 || dxl_model[i] == AX18 || dxl_model[i] == XL320)
             {
-                value = ((300.0 * (float)position[i]) / (1024.0 - 1.0)) - (300.0 / 2);
+                value = angular_position_from_deg(((300.0 * (float)position[i]) / (1024.0 - 1.0)) - (300.0 / 2));
             }
             else
             {
-                value = ((360.0 * (float)position[i]) / (4096.0 - 1.0)) - (360.0 / 2);
+                value = angular_position_from_deg(((360.0 * (float)position[i]) / (4096.0 - 1.0)) - (360.0 / 2));
             }
-            dxl[last].val = value;
+            dxl[last].val = angular_position_to_deg(value);
             dxl[last].module_pointer = module;
             dxl[last].mode = MODE_ANGLE;
             last++;


### PR DESCRIPTION
Fix an issue when turning the compliancy on dxl motors.

* First, the position used was the raw dxl value instead of the angular position in deg.
* Second, the goal position should only be set when the compliance is turned off, otherwise it will turn the motor back stiff