### PR TITLE
Fix compilation for STM32 platform 10.0.0

### DIFF
--- a/Projects/Bike_alarm/Alarm_controller/boards/l0.json
+++ b/Projects/Bike_alarm/Alarm_controller/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Bike_alarm/Start_controller/boards/l0.json
+++ b/Projects/Bike_alarm/Start_controller/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Button/boards/l0.json
+++ b/Projects/Button/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Controller_motor/boards/l0.json
+++ b/Projects/Controller_motor/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Dc_motor/boards/l0.json
+++ b/Projects/Dc_motor/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Detection/boards/l0.json
+++ b/Projects/Detection/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Distance/boards/l0.json
+++ b/Projects/Distance/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Dxl/boards/l0.json
+++ b/Projects/Dxl/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Gate/boards/l0.json
+++ b/Projects/Gate/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Gpio/boards/l0.json
+++ b/Projects/Gpio/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Imu/boards/l0.json
+++ b/Projects/Imu/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Led/boards/l0.json
+++ b/Projects/Led/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Led_strip/boards/l0.json
+++ b/Projects/Led_strip/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Light_sensor/boards/l0.json
+++ b/Projects/Light_sensor/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Load/boards/l0.json
+++ b/Projects/Load/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Potentiometer/boards/l0.json
+++ b/Projects/Potentiometer/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Power_switch/boards/l0.json
+++ b/Projects/Power_switch/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Servo/boards/l0.json
+++ b/Projects/Servo/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"

--- a/Projects/Stepper/boards/l0.json
+++ b/Projects/Stepper/boards/l0.json
@@ -8,7 +8,8 @@
             "-DLUOSHAL=STM32F0 "
         ],
         "f_cpu": "48000000L",
-        "mcu": "stm32f072vbt6"
+        "mcu": "stm32f072vbt6",
+        "product_line": "STM32F072XB"
     },
     "connectivity": [
         "can"


### PR DESCRIPTION
As explained in https://community.platformio.org/t/compilation-failure-using-platform-ststm32-10-0-0/17491/4?u=maxgerhardt, the new STM32 Platform 10.0.0 has majorly redone STM32 support and now requires an additional information field in the board's JSON file to identify the needed startup file, in this case `startup_stm32f072xb.s` for your STM32F072VBT6 chip. Compilation now goes through. 